### PR TITLE
Fix packaged web UI 404 and improve mobile websocket stability

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,5 +3,6 @@
 .DS_Store
 docs
 *.html
+!public/index.html
 ROADMAP.md
 MOBILE.md

--- a/extensions/mirror-server.ts
+++ b/extensions/mirror-server.ts
@@ -22,13 +22,35 @@ const PORT = parseInt(process.env.TAU_MIRROR_PORT || "3001");
 const STATIC_DIR = process.env.TAU_STATIC_DIR || findPublicDir();
 
 function findPublicDir(): string {
-    // 1. Check bundled "public" folder inside extension dir
-    const bundledPublic = path.resolve(__dirname, "public");
-    if (fs.existsSync(path.join(bundledPublic, "index.html"))) return bundledPublic;
-    // 2. Check sibling "public" folder (when running from pi-web-ui repo)
-    const siblingPublic = path.resolve(__dirname, "../public");
-    if (fs.existsSync(path.join(siblingPublic, "index.html"))) return siblingPublic;
-    // 3. Fall back to CWD/public
+    const candidates: string[] = [];
+    const seen = new Set<string>();
+    const addCandidate = (dir: string) => {
+      const normalized = path.resolve(dir);
+      if (seen.has(normalized)) return;
+      seen.add(normalized);
+      candidates.push(normalized);
+    };
+
+    // 1) Common extension-relative paths
+    addCandidate(path.resolve(__dirname, "public"));
+    addCandidate(path.resolve(__dirname, "../public"));
+
+    // 2) Installed package path (for npm-installed extension execution)
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const pkgPath = require.resolve("tau-mirror/package.json");
+      addCandidate(path.join(path.dirname(pkgPath), "public"));
+    } catch {}
+
+    // 3) Development fallback from current working directory
+    addCandidate(path.resolve(process.cwd(), "public"));
+    addCandidate(path.resolve(process.cwd(), "node_modules/tau-mirror/public"));
+
+    for (const candidate of candidates) {
+      if (fs.existsSync(path.join(candidate, "index.html"))) return candidate;
+    }
+
+    // Keep previous fallback behavior
     return path.resolve(process.cwd(), "public");
 }
 const SESSIONS_DIR = path.join(process.env.HOME || "~", ".pi/agent/sessions");
@@ -92,6 +114,7 @@ const MIME_TYPES: Record<string, string> = {
 export default function (pi: ExtensionAPI) {
   let server: http.Server | null = null;
   let wss: WebSocketServer | null = null;
+  let heartbeatTimer: NodeJS.Timeout | null = null;
   const clients = new Set<WebSocket>();
 
   // Store latest context reference for use in command handlers
@@ -1173,6 +1196,11 @@ img{border-radius:12px}a{color:#b87a5c;font-size:18px;margin-top:16px}p{color:rg
     wss.on("connection", (ws) => {
       console.log("[Mirror] Browser client connected");
       clients.add(ws);
+      (ws as any).isAlive = true;
+
+      ws.on("pong", () => {
+        (ws as any).isAlive = true;
+      });
 
       // Send initial state
       sendTo(ws, { type: "state", isStreaming: false, mode: "mirror" });
@@ -1203,6 +1231,25 @@ img{border-radius:12px}a{color:#b87a5c;font-size:18px;margin-top:16px}p{color:rg
         clients.delete(ws);
       });
     });
+
+    // Heartbeat keeps mobile/Tailscale sessions alive and removes stale clients.
+    heartbeatTimer = setInterval(() => {
+      for (const client of clients) {
+        if (client.readyState !== WebSocket.OPEN) {
+          clients.delete(client);
+          continue;
+        }
+
+        if (!(client as any).isAlive) {
+          try { client.terminate(); } catch {}
+          clients.delete(client);
+          continue;
+        }
+
+        (client as any).isAlive = false;
+        try { client.ping(); } catch {}
+      }
+    }, 20000);
 
     const tryListen = (port: number, maxAttempts = 10) => {
       server!.listen(port, "0.0.0.0", () => {
@@ -1280,6 +1327,10 @@ img{border-radius:12px}a{color:#b87a5c;font-size:18px;margin-top:16px}p{color:rg
   // Cleanup on shutdown
   // ═══════════════════════════════════════
   pi.on("session_shutdown", async () => {
+    if (heartbeatTimer) {
+      clearInterval(heartbeatTimer);
+      heartbeatTimer = null;
+    }
     if (wss) {
       for (const client of clients) {
         client.close();

--- a/public/websocket-client.js
+++ b/public/websocket-client.js
@@ -8,16 +8,27 @@ export class WebSocketClient extends EventTarget {
     this.url = url;
     this.ws = null;
     this.reconnectAttempts = 0;
-    this.maxReconnectAttempts = 5;
+    this.maxReconnectAttempts = Infinity;
     this.reconnectDelay = 1000;
+    this.maxReconnectDelay = 10000;
     this.isIntentionallyClosed = false;
+    this.reconnectTimer = null;
+    this.connectionState = 'idle';
   }
 
   connect() {
+    if (this.connectionState === 'connecting') return;
+    if (this.ws && this.ws.readyState === WebSocket.OPEN) return;
+    if (this.ws && this.ws.readyState === WebSocket.CONNECTING) return;
+
     this.isIntentionallyClosed = false;
-    // Close any stale socket before reconnecting
-    if (this.ws) {
-      try { this.ws.close(); } catch (e) {}
+    this.connectionState = 'connecting';
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    // Close only fully stale sockets before reconnecting
+    if (this.ws && (this.ws.readyState === WebSocket.CLOSING || this.ws.readyState === WebSocket.CLOSED)) {
       this.ws = null;
     }
     this.ws = new WebSocket(this.url);
@@ -25,6 +36,7 @@ export class WebSocketClient extends EventTarget {
     this.ws.onopen = () => {
       console.log('[WS] Connected');
       this.reconnectAttempts = 0;
+      this.connectionState = 'open';
       this.dispatchEvent(new CustomEvent('connected'));
     };
 
@@ -42,8 +54,9 @@ export class WebSocketClient extends EventTarget {
       this.dispatchEvent(new CustomEvent('error', { detail: error }));
     };
 
-    this.ws.onclose = () => {
-      console.log('[WS] Disconnected');
+    this.ws.onclose = (event) => {
+      console.log(`[WS] Disconnected (code=${event.code}, reason=${event.reason || 'n/a'})`);
+      this.connectionState = 'closed';
       this.dispatchEvent(new CustomEvent('disconnected'));
 
       if (!this.isIntentionallyClosed) {
@@ -54,6 +67,11 @@ export class WebSocketClient extends EventTarget {
 
   disconnect() {
     this.isIntentionallyClosed = true;
+    this.connectionState = 'closed';
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
     if (this.ws) {
       this.ws.close();
     }
@@ -62,7 +80,15 @@ export class WebSocketClient extends EventTarget {
   // Force reconnect — resets attempt counter and connects fresh
   forceReconnect() {
     this.reconnectAttempts = 0;
-    this.isIntentionallyClosed = true; // suppress 'disconnected' event from stale close
+    this.isIntentionallyClosed = false;
+    this.connectionState = 'closed';
+    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+      try { this.ws.close(1000, 'force reconnect'); } catch (e) {}
+    }
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
     this.connect();
   }
 
@@ -74,11 +100,12 @@ export class WebSocketClient extends EventTarget {
     }
 
     this.reconnectAttempts++;
-    const delay = this.reconnectDelay * Math.pow(2, this.reconnectAttempts - 1);
+    const delay = Math.min(this.maxReconnectDelay, this.reconnectDelay * Math.pow(2, this.reconnectAttempts - 1));
     
     console.log(`[WS] Reconnecting in ${delay}ms (attempt ${this.reconnectAttempts}/${this.maxReconnectAttempts})`);
     
-    setTimeout(() => {
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
       this.connect();
     }, delay);
   }


### PR DESCRIPTION
## Summary
This PR addresses two issues observed when running Tau from the published npm package on mobile/Tailscale:

1. `GET /` returns `404 Not Found` in some installs.
2. Browser clients on mobile networks intermittently disconnect/reconnect in loops.

## Root Causes
- `.npmignore` excluded `*.html`, which also excluded `public/index.html` from the published package.
- WebSocket lifecycle handling was optimistic for mobile conditions:
  - no server-side heartbeat/ping health check
  - reconnect logic could thrash on unstable links/backgrounding

## Changes
### 1) Ensure `public/index.html` is included in npm package
- Updated `.npmignore` to keep `public/index.html` in the published tarball.

### 2) Make static directory resolution more robust
- `findPublicDir()` now checks multiple safe candidates:
  - extension-relative paths
  - installed package path via `require.resolve("tau-mirror/package.json")`
  - common dev fallbacks from `cwd`

### 3) Improve WebSocket stability for mobile/Tailscale
#### Server (`extensions/mirror-server.ts`)
- Added heartbeat interval (20s):
  - mark socket alive on `pong`
  - send `ping`
  - terminate/remove stale sockets
- Added heartbeat cleanup on `session_shutdown`.

#### Client (`public/websocket-client.js`)
- Added connection-state guards to avoid duplicate concurrent reconnect attempts.
- Switched to capped exponential backoff (`maxReconnectDelay = 10s`).
- Improved forced reconnect behavior and timer cleanup.
- Added close-code/reason logging for easier diagnosis.

## Validation
- `npm pack --dry-run` now shows `public/index.html` included.
- JS/TS syntax checks pass for modified files.
- Runtime behavior:
  - root path serves UI (`/` no longer 404 when package assets are present)
  - websocket reconnect behavior is significantly less thrashy under unstable/mobile conditions.

## Notes
- No machine-specific paths, credentials, or user-identifying details are introduced in this patch.
