### PR TITLE
Fixes WebSocket connection failure when tau-mirror is accessed via HTTPS.

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -14,7 +14,7 @@ import { Launcher } from './launcher.js';
 
 
 // Initialize components
-const wsUrl = `ws://${window.location.host}/ws`;
+const wsUrl = (location.protocol === 'https:' ? 'wss:' : 'ws:') + '//' + location.host + '/ws';
 const wsClient = new WebSocketClient(wsUrl);
 const state = new StateManager();
 const messageRenderer = new MessageRenderer(document.getElementById('messages'));


### PR DESCRIPTION
Fix  #7 

# Why this is needed

Browsers block "mixed content" - when an HTTPS page tries to connect to an insecure `ws://` WebSocket. The fix dynamically selects the correct protocol:

- HTTPS page → `wss://` (secure WebSocket)
- HTTP page → `ws://` (standard WebSocket)

## Use Cases Enabled

This fix enables tau-mirror to work behind:
- nginx with SSL termination

## Testing

Tested with:
- ✅ nginx reverse proxy + HTTPS + basic auth