### PR TITLE
Add TAU_HOST

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,14 @@ Type `/qr` in the terminal to show a QR code and scan it to access via your phon
 
 Environment variables (set before starting Pi):
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `TAU_MIRROR_PORT` | `3001` | Server port |
-| `TAU_STATIC_DIR` | *(bundled)* | Override static files path |
-| `TAU_DISABLED` | `0` | Set to `1` to disable Tau (it stays installed but won't start the server) |
-| `TAU_USER` | *(none)* | HTTP Basic Auth username (both `TAU_USER` and `TAU_PASS` required to enable) |
-| `TAU_PASS` | *(none)* | HTTP Basic Auth password |
+| Variable          | Default     | Description                                                                  |
+|-------------------|-------------|------------------------------------------------------------------------------|
+| `TAU_MIRROR_PORT` | `3001`      | Server port                                                                  |
+| `TAU_HOST`        | `0.0.0.0`   | Bind address. Set to `127.0.0.1` to restrict to localhost only               |
+| `TAU_STATIC_DIR`  | *(bundled)* | Override static files path                                                   |
+| `TAU_DISABLED`    | `0`         | Set to `1` to disable Tau (it stays installed but won't start the server)    |
+| `TAU_USER`        | *(none)*    | HTTP Basic Auth username (both `TAU_USER` and `TAU_PASS` required to enable) |
+| `TAU_PASS`        | *(none)*    | HTTP Basic Auth password                                                     |
 
 ### Authentication
 

--- a/extensions/mirror-server.ts
+++ b/extensions/mirror-server.ts
@@ -18,7 +18,7 @@ import * as path from "node:path";
 import QRCode from "qrcode";
 
 // Load tau settings from ~/.pi/agent/settings.json (falls back to env vars)
-function loadTauSettings(): { port: number; autoStart: boolean; user: string; pass: string; authEnabled?: boolean; projectsDir?: string } {
+function loadTauSettings(): { port: number; host: string; autoStart: boolean; user: string; pass: string; authEnabled?: boolean; projectsDir?: string } {
   let settings: any = {};
   try {
     const settingsPath = path.join(process.env.HOME || "~", ".pi/agent/settings.json");
@@ -26,6 +26,7 @@ function loadTauSettings(): { port: number; autoStart: boolean; user: string; pa
   } catch {}
   return {
     port: parseInt(process.env.TAU_MIRROR_PORT || settings.port || "3001"),
+    host: process.env.TAU_HOST || settings.host || "0.0.0.0",
     autoStart: !(
       process.env.TAU_DISABLED === "1" || process.env.TAU_DISABLED === "true" ||
       settings.disabled === true
@@ -39,6 +40,7 @@ function loadTauSettings(): { port: number; autoStart: boolean; user: string; pa
 
 const TAU_SETTINGS = loadTauSettings();
 const PORT = TAU_SETTINGS.port;
+const HOST = TAU_SETTINGS.host;
 const TAU_AUTO_START = TAU_SETTINGS.autoStart;
 const AUTH_USER = TAU_SETTINGS.user;
 const AUTH_PASS = TAU_SETTINGS.pass;
@@ -1539,7 +1541,7 @@ img{border-radius:12px}a{color:#b87a5c;font-size:18px;margin-top:16px}p{color:rg
     }, 20000);
 
     const tryListen = (port: number, maxAttempts = 10) => {
-      server!.listen(port, "0.0.0.0", () => {
+      server!.listen(port, HOST, () => {
         onListening(port);
       });
       server!.once("error", (err: any) => {
@@ -1554,45 +1556,49 @@ img{border-radius:12px}a{color:#b87a5c;font-size:18px;margin-top:16px}p{color:rg
     };
 
     const onListening = (port: number) => {
-      // Get local IP for display — prefer en0/en1 (WiFi/Ethernet) over bridges/VPNs
-      const nets = require("node:os").networkInterfaces();
+      const isLoopback = HOST === "127.0.0.1" || HOST === "::1" || HOST === "localhost";
+
       let localIp = "localhost";
-      let fallbackIp = "";
-      const preferred = ["en0", "en1"]; // WiFi and Ethernet adapters
-      for (const name of preferred) {
-        for (const net of nets[name] || []) {
-          if (net.family === "IPv4" && !net.internal) {
-            localIp = net.address;
-            break;
-          }
-        }
-        if (localIp !== "localhost") break;
-      }
-      // Fallback: any LAN IP that isn't a bridge or VPN
-      if (localIp === "localhost") {
-        for (const name of Object.keys(nets)) {
-          if (name.startsWith("bridge") || name.startsWith("utun") || name.startsWith("lo")) continue;
+      let tailscaleIp = "";
+
+      if (!isLoopback) {
+        // Get local IP for display — prefer en0/en1 (WiFi/Ethernet) over bridges/VPNs
+        const nets = require("node:os").networkInterfaces();
+        let fallbackIp = "";
+        const preferred = ["en0", "en1"];
+        for (const name of preferred) {
           for (const net of nets[name] || []) {
-            if (net.family === "IPv4" && !net.internal && (net.address.startsWith("192.168.") || net.address.startsWith("10."))) {
+            if (net.family === "IPv4" && !net.internal) {
               localIp = net.address;
               break;
             }
           }
           if (localIp !== "localhost") break;
         }
-      }
-      if (localIp === "localhost" && fallbackIp) localIp = fallbackIp;
-
-      // Detect Tailscale IP (100.x.x.x CGNAT range)
-      let tailscaleIp = "";
-      for (const name of Object.keys(nets)) {
-        for (const net of nets[name] || []) {
-          if (net.family === "IPv4" && !net.internal && net.address.startsWith("100.")) {
-            tailscaleIp = net.address;
-            break;
+        if (localIp === "localhost") {
+          for (const name of Object.keys(nets)) {
+            if (name.startsWith("bridge") || name.startsWith("utun") || name.startsWith("lo")) continue;
+            for (const net of nets[name] || []) {
+              if (net.family === "IPv4" && !net.internal && (net.address.startsWith("192.168.") || net.address.startsWith("10."))) {
+                localIp = net.address;
+                break;
+              }
+            }
+            if (localIp !== "localhost") break;
           }
         }
-        if (tailscaleIp) break;
+        if (localIp === "localhost" && fallbackIp) localIp = fallbackIp;
+
+        // Detect Tailscale IP (100.x.x.x CGNAT range)
+        for (const name of Object.keys(nets)) {
+          for (const net of nets[name] || []) {
+            if (net.family === "IPv4" && !net.internal && net.address.startsWith("100.")) {
+              tailscaleIp = net.address;
+              break;
+            }
+          }
+          if (tailscaleIp) break;
+        }
       }
 
       mirrorUrl = `http://${localIp}:${port}`;


### PR DESCRIPTION
- loadTauSettings() now returns a host field — reads TAU_HOST env var first, then settings.host from ~/.pi/agent/settings.json, defaulting to "0.0.0.0" (existing behavior preserved)
- A HOST constant is exported alongside PORT
- server.listen() now uses HOST instead of the hardcoded "0.0.0.0"
- onListening skips LAN/Tailscale IP detection entirely when bound to loopback (127.0.0.1/localhost/::1), so the status bar and QR code correctly show localhost rather than a useless LAN IP