### PR TITLE
fix: guard win32 from Unix-only ps/tmux calls at startup

### DIFF
--- a/extensions/mirror-server.ts
+++ b/extensions/mirror-server.ts
@@ -130,6 +130,7 @@ function getRunningInstances(): Array<{ port: number; pid: number; sessionFile: 
  * If it doesn't, the HTTP server is the only thing keeping it alive.
  */
 function cleanupZombieInstances() {
+  if (process.platform === "win32") return;
   if (!fs.existsSync(INSTANCES_DIR)) return;
   const { execSync } = require("node:child_process");
   for (const file of fs.readdirSync(INSTANCES_DIR)) {
@@ -1043,6 +1044,7 @@ img{border-radius:12px}a{color:#b87a5c;font-size:18px;margin-top:16px}p{color:rg
   // Sessions list endpoint
   // ═══════════════════════════════════════
   function getTmuxSessionFiles(): Set<string> {
+    if (process.platform === "win32") return new Set();
     try {
       const { execSync } = require("node:child_process");
       // Get tmux pane PIDs


### PR DESCRIPTION
## Problem

On Windows, two code paths crash at server startup with _"Das System kann den angegebenen Pfad nicht finden."_:

- \`cleanupZombieInstances()\` calls \`ps\` with \`2>/dev/null\` — neither \`ps\` nor \`/dev/null\` exist on Windows
- \`getTmuxSessionFiles()\` calls \`tmux\` — not available on Windows

## Fix

Add an early \`process.platform === "win32"\` guard to both functions so they return immediately without attempting Unix-only system calls.

No behaviour change on macOS or Linux.