### PR TITLE
fix: cross-platform file manager button and tooltip

### DIFF
--- a/extensions/mirror-server.ts
+++ b/extensions/mirror-server.ts
@@ -885,7 +885,7 @@ img{border-radius:12px}a{color:#b87a5c;font-size:18px;margin-top:16px}p{color:rg
 
     if (urlPath === "/api/health") {
       res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ status: "ok", mode: "mirror", mirrorUrl, tailscaleUrl: tailscaleUrl || undefined }));
+      res.end(JSON.stringify({ status: "ok", mode: "mirror", mirrorUrl, tailscaleUrl: tailscaleUrl || undefined, platform: process.platform }));
       return;
     }
 
@@ -981,9 +981,21 @@ img{border-radius:12px}a{color:#b87a5c;font-size:18px;margin-top:16px}p{color:rg
             return;
           }
           const { execFile } = await import("node:child_process");
-          execFile("open", [fp], (err) => {
-            if (err) console.error("[Mirror] open failed:", err.message);
-          });
+          if (process.platform === "win32") {
+            const { exec } = await import("node:child_process");
+            const safe = fp.replace(/'/g, "''").replace(/"/g, '');
+            exec(`powershell -NoProfile -WindowStyle Hidden -Command "& { $wsh = New-Object -ComObject WScript.Shell; $wsh.Run('explorer \\"${safe}\\"', 1, $false) }"`, (err) => {
+              if (err) console.error("[Mirror] open failed:", err.message);
+            });
+          } else if (process.platform === "darwin") {
+            execFile("open", [fp], (err) => {
+              if (err) console.error("[Mirror] open failed:", err.message);
+            });
+          } else {
+            execFile("xdg-open", [fp], (err) => {
+              if (err) console.error("[Mirror] open failed:", err.message);
+            });
+          }
           res.writeHead(200, { "Content-Type": "application/json" });
           res.end(JSON.stringify({ ok: true }));
         } catch (err: any) {

--- a/public/app.js
+++ b/public/app.js
@@ -93,6 +93,12 @@ fileSidebarUp.addEventListener('click', () => {
   if (parent) fileBrowser.load(parent);
 });
 
+fetch('/api/health').then(r => r.json()).then(data => {
+  const names = { win32: 'Explorer', darwin: 'Finder', linux: 'file manager' };
+  const name = names[data.platform] || 'file manager';
+  document.getElementById('file-sidebar-finder').title = `Open in ${name}`;
+}).catch(() => {});
+
 document.getElementById('file-sidebar-finder').addEventListener('click', () => {
   if (fileBrowser.currentPath) {
     fetch('/api/open', {


### PR DESCRIPTION
## Problem

The \"Open in file manager\" button called the macOS-only \`open\` command, causing \`[Mirror] open failed: spawn open ENOENT\` on Windows and Linux.

The tooltip always read \"Open in file manager\" regardless of platform.

## Fix

- \`/api/open\` now uses \`WScript.Shell\` via PowerShell on \`win32\`, \`open\` on \`darwin\`, and \`xdg-open\` on \`linux\`
- \`/api/health\` exposes \`process.platform\` so the frontend can read it
- \`app.js\` fetches the platform on load and sets the tooltip to \"Open in Explorer\" (win32), \"Open in Finder\" (darwin), or \"Open in file manager\" (linux)