### PR TITLE
fix: parent directory navigation broken on Windows

### DIFF
--- a/public/file-browser.js
+++ b/public/file-browser.js
@@ -73,9 +73,12 @@ export class FileBrowser {
 
   getParentPath() {
     if (!this.currentPath) return null;
-    const parts = this.currentPath.split('/');
-    parts.pop();
-    return parts.join('/') || '/';
+    const sep = this.currentPath.includes('\\') ? '\\' : '/';
+    const normalized = this.currentPath.endsWith(sep) ? this.currentPath.slice(0, -1) : this.currentPath;
+    const lastSep = normalized.lastIndexOf(sep);
+    if (lastSep <= 0) return sep === '/' ? '/' : null;
+    const parent = normalized.slice(0, lastSep);
+    return /^[A-Za-z]:$/.test(parent) ? parent + sep : parent;
   }
 
   render(items) {


### PR DESCRIPTION
## Problem

The "Parent directory" button in the file browser always navigated to `/` on Windows.

`getParentPath()` split the current path on `/`, but Windows paths use `\` as separator. For a path like `C:\Users\slu\Documents`, the split produced a single element, resulting in an empty join that fell back to `/`.

## Fix

Detect the path separator via `lastIndexOf` instead of splitting on a hardcoded `/`. Also handles Windows drive roots correctly (`C:\Users` → `C:\`, `C:\` → disabled).

No behaviour change on macOS or Linux.