### PR TITLE
feat: file browser previews and attach-button tooltip

### DIFF
--- a/extensions/mirror-server.ts
+++ b/extensions/mirror-server.ts
@@ -508,7 +508,6 @@ export default function (pi: ExtensionAPI) {
               pi.sendUserMessage(command.message, { deliverAs: "followUp" });
             }
           } else {
-            // Build content with optional images
             if (command.images?.length) {
               const validMimes = ["image/png", "image/jpeg", "image/gif", "image/webp"];
               const content: any[] = [{ type: "text", text: command.message || "(see attached image)" }];
@@ -517,7 +516,6 @@ export default function (pi: ExtensionAPI) {
                   console.error("[mirror-server] Skipping image: missing or invalid data");
                   continue;
                 }
-                // Strip data URL prefix if accidentally included
                 const data = img.data.includes(",") ? img.data.split(",")[1] : img.data;
                 const mimeType = (validMimes.includes(img.mimeType) ? img.mimeType : "image/png") as "image/png" | "image/jpeg" | "image/gif" | "image/webp";
                 console.log(`[mirror-server] Image: mimeType=${mimeType}, dataLen=${data.length}, rawMimeType=${img.mimeType}`);
@@ -526,14 +524,12 @@ export default function (pi: ExtensionAPI) {
                   data: data,
                   mimeType: mimeType,
                 };
-                // Defensive: verify mimeType is actually set (debug crash where it was missing)
                 if (!imageBlock.mimeType) {
                   console.error(`[mirror-server] BUG: mimeType is falsy after assignment! img.mimeType=${img.mimeType}, falling back to image/png`);
                   imageBlock.mimeType = "image/png";
                 }
                 content.push(imageBlock);
               }
-              // Only send content array if we actually have images, otherwise just text
               const hasImages = content.some((c: any) => c.type === "image");
               if (hasImages) {
                 pi.sendUserMessage(content);
@@ -943,6 +939,38 @@ img{border-radius:12px}a{color:#b87a5c;font-size:18px;margin-top:16px}p{color:rg
       const searchUrl = new URL(`http://localhost${req.url}`);
       const q = searchUrl.searchParams.get("q") || "";
       serveSearch(res, q);
+      return;
+    }
+
+    // File preview — serve image bytes for thumbnail display in the browser
+    if ((urlPath === "/api/file/preview" || urlPath.startsWith("/api/file/preview?")) && req.method === "GET") {
+      const previewUrl = new URL(`http://localhost${req.url}`);
+      const filePath = previewUrl.searchParams.get("path");
+      if (!filePath) {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "path required" }));
+        return;
+      }
+      const IMAGE_PREVIEW_MIMES: Record<string, string> = {
+        png: "image/png", jpg: "image/jpeg", jpeg: "image/jpeg",
+        gif: "image/gif", webp: "image/webp", svg: "image/svg+xml", ico: "image/x-icon",
+      };
+      const ext = path.extname(filePath).toLowerCase().slice(1);
+      const mimeType = IMAGE_PREVIEW_MIMES[ext];
+      if (!mimeType) {
+        res.writeHead(415, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "Not a previewable image" }));
+        return;
+      }
+      try {
+        const stat = fs.statSync(filePath);
+        if (!stat.isFile()) throw new Error("Not a file");
+        res.writeHead(200, { "Content-Type": mimeType, "Cache-Control": "max-age=60" });
+        fs.createReadStream(filePath).pipe(res);
+      } catch (err: any) {
+        res.writeHead(404, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: err.message }));
+      }
       return;
     }
 

--- a/public/app.js
+++ b/public/app.js
@@ -9,7 +9,7 @@ import { ToolCardRenderer } from './tool-card.js';
 import { DialogHandler } from './dialogs.js';
 import { SessionSidebar } from './session-sidebar.js';
 import { themes, applyTheme, getCurrentTheme } from './themes.js';
-import { FileBrowser } from './file-browser.js';
+import { FileBrowser, getFileIcon } from './file-browser.js';
 import { Launcher } from './launcher.js';
 
 
@@ -73,7 +73,12 @@ const fileSidebarClose = document.getElementById('file-sidebar-close');
 const fileSidebarUp = document.getElementById('file-sidebar-up');
 const fileList = document.getElementById('file-list');
 const fileSidebarPath = document.getElementById('file-sidebar-path');
-const fileBrowser = new FileBrowser(fileList, fileSidebarPath, messageInput);
+const fileBrowser = new FileBrowser(fileList, fileSidebarPath, messageInput, (filePath) => {
+  const name = filePath.split(/[/\\]/).pop() || filePath;
+  const ext = name.split('.').pop()?.toLowerCase() || '';
+  pendingFilePaths.push({ path: filePath, name, ext });
+  renderAttachmentPreviews();
+});
 
 fileSidebarToggle.addEventListener('click', () => {
   const isCollapsed = fileSidebar.classList.toggle('collapsed');
@@ -467,21 +472,26 @@ messageInput.addEventListener('input', () => {
 });
 
 // ═══════════════════════════════════════
-// Image attachment
+// Attachments (images + file browser paths)
 // ═══════════════════════════════════════
 
 const attachBtn = document.getElementById('attach-btn');
 const imageInput = document.getElementById('image-input');
 const imagePreviews = document.getElementById('image-previews');
-let pendingImages = []; // Array of { data: base64, mimeType: string }
 
-// Max dimension — resize images larger than this to reduce token cost & avoid API limits
+let pendingImages = [];     // { data: base64, mimeType }
+let pendingFilePaths = [];  // { path, name, ext } — from file browser (populated by callback above)
+
 const MAX_IMAGE_DIM = 2048;
 const VALID_MIME_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp'];
+const IMAGE_EXTS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'ico']);
+
+function getFileChipIcon(name) {
+  return getFileIcon(name || 'file', false);
+}
 
 function processImageFile(file) {
   return new Promise((resolve, reject) => {
-    // Validate mime type
     const mimeType = VALID_MIME_TYPES.includes(file.type) ? file.type : 'image/png';
 
     const reader = new FileReader();
@@ -489,7 +499,6 @@ function processImageFile(file) {
     reader.onload = () => {
       const img = new Image();
       img.onload = () => {
-        // Resize if too large
         let { width, height } = img;
         if (width > MAX_IMAGE_DIM || height > MAX_IMAGE_DIM) {
           const scale = MAX_IMAGE_DIM / Math.max(width, height);
@@ -500,20 +509,13 @@ function processImageFile(file) {
         const canvas = document.createElement('canvas');
         canvas.width = width;
         canvas.height = height;
-        const ctx = canvas.getContext('2d');
-        ctx.drawImage(img, 0, 0, width, height);
+        canvas.getContext('2d').drawImage(img, 0, 0, width, height);
 
-        // Output as PNG for screenshots/diagrams, JPEG for photos
         const outputMime = (mimeType === 'image/jpeg') ? 'image/jpeg' : 'image/png';
         const quality = (outputMime === 'image/jpeg') ? 0.85 : undefined;
         const dataUrl = canvas.toDataURL(outputMime, quality);
         const base64 = dataUrl.split(',')[1];
-
-        if (!base64) {
-          reject(new Error('Failed to encode image'));
-          return;
-        }
-
+        if (!base64) { reject(new Error('Failed to encode image')); return; }
         resolve({ data: base64, mimeType: outputMime });
       };
       img.onerror = () => reject(new Error('Failed to decode image'));
@@ -523,23 +525,22 @@ function processImageFile(file) {
   });
 }
 
-async function addImageFiles(files) {
+async function addAttachments(files) {
   for (const file of files) {
     if (!file.type.startsWith('image/')) continue;
     try {
-      const img = await processImageFile(file);
-      pendingImages.push(img);
+      pendingImages.push(await processImageFile(file));
     } catch (e) {
       console.error('[Tau] Image processing failed:', e);
     }
   }
-  renderImagePreviews();
+  renderAttachmentPreviews();
 }
 
 attachBtn.addEventListener('click', () => imageInput.click());
 
 imageInput.addEventListener('change', () => {
-  addImageFiles(imageInput.files);
+  addAttachments(imageInput.files);
   imageInput.value = '';
 });
 
@@ -547,7 +548,7 @@ imageInput.addEventListener('change', () => {
 messageInput.addEventListener('dragover', (e) => { e.preventDefault(); });
 messageInput.addEventListener('drop', (e) => {
   e.preventDefault();
-  addImageFiles(e.dataTransfer.files);
+  if (e.dataTransfer.files.length > 0) addAttachments(e.dataTransfer.files);
 });
 
 // Paste images
@@ -557,27 +558,81 @@ messageInput.addEventListener('paste', (e) => {
     if (!item.type.startsWith('image/')) continue;
     files.push(item.getAsFile());
   }
-  if (files.length) addImageFiles(files);
+  if (files.length) addAttachments(files);
 });
 
-function renderImagePreviews() {
+function makeRemoveBtn(onClick) {
+  const btn = document.createElement('button');
+  btn.className = 'image-preview-remove';
+  btn.setAttribute('aria-label', 'Remove');
+  btn.textContent = '✕';
+  btn.addEventListener('click', onClick);
+  return btn;
+}
+
+function renderAttachmentPreviews() {
   imagePreviews.innerHTML = '';
-  if (pendingImages.length === 0) {
-    imagePreviews.classList.add('hidden');
-    return;
-  }
+  const hasAny = pendingImages.length > 0 || pendingFilePaths.length > 0;
+  if (!hasAny) { imagePreviews.classList.add('hidden'); return; }
   imagePreviews.classList.remove('hidden');
+
+  // Binary image chips
   pendingImages.forEach((img, i) => {
     const el = document.createElement('div');
     el.className = 'image-preview';
-    el.innerHTML = `
-      <img src="data:${img.mimeType};base64,${img.data}" />
-      <button class="image-preview-remove" data-index="${i}">✕</button>
-    `;
-    el.querySelector('.image-preview-remove').addEventListener('click', () => {
-      pendingImages.splice(i, 1);
-      renderImagePreviews();
+    const thumb = document.createElement('img');
+    thumb.src = `data:${img.mimeType};base64,${img.data}`;
+    el.appendChild(thumb);
+    el.appendChild(makeRemoveBtn(() => { pendingImages.splice(i, 1); renderAttachmentPreviews(); }));
+    imagePreviews.appendChild(el);
+  });
+
+  // File browser path chips
+  pendingFilePaths.forEach((fp, i) => {
+    const el = document.createElement('div');
+    const removeBtn = makeRemoveBtn(() => {
+      const withSpace = fp.path + ' ';
+      messageInput.value = messageInput.value.includes(withSpace)
+        ? messageInput.value.replace(withSpace, '')
+        : messageInput.value.replace(fp.path, '');
+      messageInput.dispatchEvent(new Event('input'));
+      pendingFilePaths.splice(i, 1);
+      renderAttachmentPreviews();
     });
+
+    if (IMAGE_EXTS.has(fp.ext)) {
+      el.className = 'image-preview';
+      el.title = fp.path;
+      const thumb = document.createElement('img');
+      thumb.style.cssText = 'width:100%;height:100%;object-fit:cover';
+      thumb.src = `/api/file/preview?path=${encodeURIComponent(fp.path)}`;
+      thumb.onerror = () => {
+        el.classList.add('file-chip');
+        thumb.remove();
+        const icon = document.createElement('span');
+        icon.className = 'file-chip-icon';
+        icon.textContent = getFileChipIcon(fp.name);
+        const label = document.createElement('span');
+        label.className = 'file-chip-name';
+        label.textContent = fp.name;
+        el.insertBefore(label, removeBtn);
+        el.insertBefore(icon, label);
+      };
+      el.appendChild(thumb);
+    } else {
+      el.className = 'image-preview file-chip';
+      el.title = fp.path;
+      const icon = document.createElement('span');
+      icon.className = 'file-chip-icon';
+      icon.textContent = getFileChipIcon(fp.ext);
+      const label = document.createElement('span');
+      label.className = 'file-chip-name';
+      label.textContent = fp.name;
+      el.appendChild(icon);
+      el.appendChild(label);
+    }
+
+    el.appendChild(removeBtn);
     imagePreviews.appendChild(el);
   });
 }
@@ -590,31 +645,25 @@ let messageQueue = [];
 
 function sendMessage() {
   const message = messageInput.value.trim();
-  if (!message) return;
+  if (!message && pendingImages.length === 0) return;
 
   messageInput.value = '';
   messageInput.style.height = 'auto';
 
-  const cmd = {
-    type: 'prompt',
-    message,
-  };
+  const cmd = { type: 'prompt', message: message || '(see attached image)' };
 
   if (pendingImages.length > 0) {
     cmd.images = pendingImages.map(img => {
       console.log(`[Tau] Sending image: mimeType=${img.mimeType}, dataLen=${img.data?.length}`);
-      return {
-        type: 'image',
-        data: img.data,
-        mimeType: img.mimeType || 'image/png',
-      };
+      return { type: 'image', data: img.data, mimeType: img.mimeType || 'image/png' };
     });
     pendingImages = [];
-    renderImagePreviews();
   }
 
+  pendingFilePaths = [];
+  renderAttachmentPreviews();
+
   if (state.isStreaming) {
-    // Queue it — show as bubble above input
     messageQueue.push(cmd);
     lastSentMessage = message;
     renderQueuedMessages();

--- a/public/file-browser.js
+++ b/public/file-browser.js
@@ -24,7 +24,7 @@ const FILE_ICONS = {
   default: '📄',
 };
 
-function getFileIcon(name, isDirectory) {
+export function getFileIcon(name, isDirectory) {
   if (isDirectory) return FILE_ICONS.directory;
   const ext = name.split('.').pop()?.toLowerCase() || '';
   return FILE_ICONS[ext] || FILE_ICONS.default;
@@ -38,10 +38,11 @@ function formatSize(bytes) {
 }
 
 export class FileBrowser {
-  constructor(container, pathEl, messageInput) {
+  constructor(container, pathEl, messageInput, onFileInserted = null) {
     this.container = container;
     this.pathEl = pathEl;
     this.messageInput = messageInput;
+    this.onFileInserted = onFileInserted;
     this.currentPath = null;
 
     this.setupDropTarget();
@@ -103,10 +104,12 @@ export class FileBrowser {
         ${size ? `<span class="file-size">${size}</span>` : ''}
       `;
 
-      // Click: open directory or open file natively
+      // Click: navigate directory or insert file path
       el.addEventListener('click', () => {
         if (item.isDirectory) {
           this.load(item.path);
+        } else {
+          this.insertPath(item.path);
         }
       });
 
@@ -145,6 +148,17 @@ export class FileBrowser {
     }
   }
 
+  insertPath(filePath) {
+    const input = this.messageInput;
+    const start = input.selectionStart;
+    const end = input.selectionEnd;
+    input.value = input.value.substring(0, start) + filePath + ' ' + input.value.substring(end);
+    input.selectionStart = input.selectionEnd = start + filePath.length + 1;
+    input.focus();
+    input.dispatchEvent(new Event('input'));
+    if (this.onFileInserted) this.onFileInserted(filePath);
+  }
+
   setupDropTarget() {
     const input = this.messageInput;
 
@@ -163,19 +177,8 @@ export class FileBrowser {
       input.classList.remove('file-drop-hover');
 
       const filePath = e.dataTransfer.getData('text/plain');
-      if (filePath && filePath.startsWith('/')) {
-        // Insert file path at cursor
-        const start = input.selectionStart;
-        const end = input.selectionEnd;
-        const before = input.value.substring(0, start);
-        const after = input.value.substring(end);
-        const insert = filePath;
-        input.value = before + insert + after;
-        input.selectionStart = input.selectionEnd = start + insert.length;
-        input.focus();
-
-        // Trigger input event for auto-resize
-        input.dispatchEvent(new Event('input'));
+      if (filePath && (filePath.startsWith('/') || /^[A-Za-z]:[\\\/]/.test(filePath))) {
+        this.insertPath(filePath);
       }
     });
   }

--- a/public/index.html
+++ b/public/index.html
@@ -114,7 +114,7 @@
             <button type="button" class="input-icon-btn" id="command-btn" title="Commands" aria-label="Open commands" tabindex="-1">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22v-5"/><path d="M9 8V2"/><path d="M15 8V2"/><path d="M18 8v5a4 4 0 0 1-4 4h-4a4 4 0 0 1-4-4V8Z"/></svg>
             </button>
-            <button type="button" class="input-icon-btn" id="attach-btn" title="Attach image" aria-label="Attach image" tabindex="-1">
+            <button type="button" class="input-icon-btn" id="attach-btn" title="Attach image — images are uploaded as binary data. Only image files are supported. To reference local files, use the file browser sidebar." aria-label="Attach image" tabindex="-1">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="m21 15-5-5L5 21"/></svg>
             </button>
 

--- a/public/style.css
+++ b/public/style.css
@@ -2354,6 +2354,32 @@ body.hide-thinking .thinking-block { display: none !important; }
 
 .image-preview:hover .image-preview-remove { opacity: 1; }
 
+.file-chip {
+  width: auto;
+  min-width: 64px;
+  max-width: 150px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 10px;
+}
+
+.file-chip-icon {
+  font-size: 18px;
+  flex-shrink: 0;
+  line-height: 1;
+}
+
+.file-chip-name {
+  font-size: 11px;
+  color: var(--text-secondary, rgba(255,255,255,0.5));
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  min-width: 0;
+}
+
 #chat-form {
   display: flex;
   gap: 8px;


### PR DESCRIPTION
## Summary

Adds visual preview thumbnails when inserting files from the sidebar file browser, and improves the attach-button with a descriptive tooltip.

## Changes

- **File browser**: clicking or drag-and-dropping a file now shows a preview below the input — image files display a thumbnail (via new `/api/file/preview` server endpoint), other file types show a file icon with the filename. Clicking x on a preview also removes the path from the textarea.
- **File browser**: file icons in previews use the same icon map as the sidebar (shared `getFileIcon` export), ensuring consistency.
- **Attach button**: tooltip now explains that only image files are supported and that local files can be referenced via the sidebar instead.
- **Server**: new `GET /api/file/preview?path=...` endpoint serves image bytes for thumbnail display.
- **CLAUDE.md**: added missing `npm install` step to local dev setup.