### PR TITLE
fix: add missing closing brace in mirror-server.ts

### DIFF
--- a/extensions/mirror-server.ts
+++ b/extensions/mirror-server.ts
@@ -1724,3 +1724,4 @@ img{border-radius:12px}a{color:#b87a5c;font-size:18px;margin-top:16px}p{color:rg
     console.log("[Mirror] Server shut down");
   });
 }
+}


### PR DESCRIPTION
The `export default function` body opened at line 215 was never closed (556 `{` vs 555 `}`), causing a `ParseError` when Pi tries to load the extension at startup. The syntax error was introduced in v1.0.8.

**Fix:** Added a trailing `}` to close the function body, restoring proper brace balance.

**Verification:**
- Before: `tsc` reports `error TS1005: '}' expected` at line 1727
- After: compiles cleanly, no syntax errors
- Brace counts: 556 `{` / 556 `}` (balanced)

**Workaround:** Pin to `tau-mirror@1.0.7` until this is merged and released.