### PR TITLE
fix: restore /api/instances handler body lost in PR #33 merge

### DIFF
--- a/extensions/mirror-server.ts
+++ b/extensions/mirror-server.ts
@@ -928,6 +928,10 @@ img{border-radius:12px}a{color:#b87a5c;font-size:18px;margin-top:16px}p{color:rg
     }
 
     if (urlPath === "/api/instances") {
+      res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+      res.end(JSON.stringify({ instances: getRunningInstances() }));
+      return;
+    }
 
     if (urlPath === "/api/projects" && req.method === "GET") {
       serveProjectsList(res);


### PR DESCRIPTION
## Root cause

The `/api/instances` handler was introduced with a correct body, but the merge of PR #33 (feat: file browser previews) accidentally dropped the three response lines and the closing brace, leaving an empty open block:

```typescript
// After PR #33 merge — broken
if (urlPath === "/api/instances") {
                                   // ← empty, no body, no return, no closing }
if (urlPath === "/api/projects" ...) {
```

Because the block is never closed, **every route handler after `/api/instances`** (`/api/projects`, `/api/sessions`, `/api/files`, the 404 handler, etc.) became nested inside it. Those routes are only reachable when `urlPath === "/api/instances"` — for any other path they are silently skipped.

This also explains the brace imbalance that PR #35 observed (`tsc` `'}' expected`).

## Why PR #35 is the wrong fix

PR #35 adds a `}` at the very end of the file. This balances the brace count and silences the `tsc` error, but the structural problem remains: all route handlers are still nested inside the `/api/instances` block. At runtime, every route except `/api/instances` would receive no response (connection hangs).

## This fix

Restores the original four lines at the correct location:

```typescript
if (urlPath === "/api/instances") {
  res.writeHead(200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
  res.end(JSON.stringify({ instances: getRunningInstances() }));
  return;
}
```

This closes the block in the right place, moves all subsequent route handlers back to the correct nesting level, and restores the intended response.