### PR TITLE
fix: resolve Chinese IME enter key issue and prevent port hijacking for multiple instances

### DIFF
--- a/extensions/mirror-server.ts
+++ b/extensions/mirror-server.ts
@@ -677,7 +677,8 @@ export default function (pi: ExtensionAPI) {
           const idx = levels.indexOf(current);
           const next = levels[(idx + 1) % levels.length];
           pi.setThinkingLevel(next as any);
-          sendTo(ws, success("cycle_thinking_level", { level: next }));
+          const actual = pi.getThinkingLevel();
+          sendTo(ws, success("cycle_thinking_level", { level: actual }));
           break;
         }
 

--- a/extensions/mirror-server.ts
+++ b/extensions/mirror-server.ts
@@ -170,6 +170,17 @@ function cleanupZombieInstances() {
   }
 }
 
+function isZombieProcess(pid: number): boolean {
+  if (process.platform === "win32") return false;
+  try {
+    const { execSync } = require("node:child_process");
+    const tty = execSync(`ps -o tty= -p ${pid}`, { encoding: "utf8" }).trim();
+    return !tty || tty === "??" || tty === "-";
+  } catch {
+    return true;
+  }
+}
+
 // MIME types for static file serving
 const MIME_TYPES: Record<string, string> = {
   ".html": "text/html",
@@ -1626,7 +1637,7 @@ img{border-radius:12px}a{color:#b87a5c;font-size:18px;margin-top:16px}p{color:rg
           // Check if a stale Tau instance owns this port and kill it
           const instances = getRunningInstances();
           const stale = instances.find(i => i.port === port && i.pid !== process.pid);
-          if (stale) {
+          if (stale && isZombieProcess(stale.pid)) {
             console.log(`[Mirror] Port ${port} in use by stale Tau instance (PID ${stale.pid}), killing...`);
             try { process.kill(stale.pid, "SIGTERM"); } catch {}
             // Wait briefly then retry the same port

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tau-mirror",
-  "version": "1.0.5",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tau-mirror",
-      "version": "1.0.5",
+      "version": "1.0.8",
       "license": "MIT",
       "dependencies": {
         "qrcode": "^1.5.0",

--- a/public/app.js
+++ b/public/app.js
@@ -465,7 +465,7 @@ chatForm.addEventListener('submit', (e) => {
 
 messageInput.addEventListener('keydown', (e) => {
   // Enter sends, Shift+Enter inserts newline
-  if (e.key === 'Enter' && !e.shiftKey) {
+  if (e.key === 'Enter' && !e.shiftKey && !e.isComposing) {
     e.preventDefault();
     sendMessage();
   }


### PR DESCRIPTION
This PR resolves two major issues in `tau-mirror`:

1. **Chinese IME Enter Key Issue:**
   - **Problem:** When typing using a Chinese Input Method Editor (IME) and pressing Enter to confirm the selected characters, the keydown event listener was triggered, causing the message to be sent prematurely.
   - **Solution:** Added `!e.isComposing` to the keydown condition in `public/app.js` to ensure the keypress is ignored during active composition.

2. **Port Hijacking Issue (Multi-terminal support):**
   - **Problem:** When starting a second `pi` session in a different terminal window, the second instance would check if port `3001` was occupied. The port detection logic assumed *any* other process using that port was stale, and unconditionally sent `SIGTERM` to kill the first active instance. This prevented running multiple sessions on separate ports (`3001`, `3002`, etc.) concurrently.
   - **Solution:** Added a TTY verification check (`isZombieProcess`). The startup logic will now only terminate a conflicting process if it is verified to be a zombie process (i.e. has no active controlling terminal). If it is a healthy, active session with a controlling TTY, the new instance will skip killing it and successfully listen on the next available port (e.g. `3002`)